### PR TITLE
fix(collab): refresh token on reconnect to prevent silent auth failure

### DIFF
--- a/apps/collab/src/index.ts
+++ b/apps/collab/src/index.ts
@@ -19,6 +19,7 @@ const server = new Server({
   port: parseInt(process.env.PORT ?? "1234", 10),
   debounce: 2000,
   maxDebounce: 10000,
+  timeout: 30000,
   quiet: false,
 
   async onAuthenticate(data) {

--- a/apps/web/src/components/notes/note/hook/useCollabProvider.ts
+++ b/apps/web/src/components/notes/note/hook/useCollabProvider.ts
@@ -1,6 +1,5 @@
 import { HocuspocusProvider } from "@hocuspocus/provider";
-import { useEffect, useState } from "react";
-import { useCollabToken } from "@/hook/notes/useCollabToken";
+import { useEffect, useRef, useState } from "react";
 
 interface UseCollabProviderParams {
   noteId: string;
@@ -11,16 +10,22 @@ export function useCollabProvider({
   noteId,
   workspaceId,
 }: UseCollabProviderParams) {
-  const { data: token } = useCollabToken({ noteId, workspaceId });
   const [provider, setProvider] = useState<HocuspocusProvider | undefined>();
+  const workspaceIdRef = useRef(workspaceId);
+  workspaceIdRef.current = workspaceId;
 
   useEffect(() => {
-    if (!token) return;
-
     const p = new HocuspocusProvider({
       url: process.env.NEXT_PUBLIC_COLLAB_WS_URL!,
       name: noteId,
-      token,
+      token: async () => {
+        const res = await fetch(
+          `/api/collab/token?noteId=${noteId}&workspaceId=${workspaceIdRef.current}`,
+        );
+        if (!res.ok) throw new Error("Failed to fetch collab token");
+        const data = await res.json();
+        return data.token;
+      },
     });
 
     setProvider(p);
@@ -29,7 +34,7 @@ export function useCollabProvider({
       p.destroy();
       setProvider(undefined);
     };
-  }, [token, noteId]);
+  }, [noteId]);
 
   return { provider };
 }


### PR DESCRIPTION
Pass token as async function so HocuspocusProvider fetches a fresh JWT on every (re)connection instead of reusing a potentially expired token. Also removes the dependency on the React Query token state, which was causing the provider to be destroyed and recreated on token refresh.

Adds timeout: 30000 on the server to close orphan documents faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Configured explicit server connection timeout to enhance reliability during real-time collaboration sessions
  * Optimized workspace context handling in collaborative editing to improve token management and provider initialization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ali-ali18/locus-refs/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->