### PR TITLE
feat(sidebar): add edit and delete actions to note items

### DIFF
--- a/apps/web/src/components/notes/EditNoteDialog.tsx
+++ b/apps/web/src/components/notes/EditNoteDialog.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { File01Icon, Loading02Icon } from "@hugeicons/core-free-icons";
+import { useEffect } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { FieldGroupApp } from "@/components/base";
+import { Icon } from "@/components/shared/Icon";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { type UpdateHeaderNoteSchema, updateHeaderNoteSchema } from "@refstash/shared";
+import { useNoteMutations } from "@/hook/notes/useNote";
+import { IconPicker } from "./IconPicker";
+
+interface EditNoteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  noteId: string;
+  currentTitle: string;
+  currentIcon?: string;
+}
+
+export function EditNoteDialog({
+  open,
+  onOpenChange,
+  noteId,
+  currentTitle,
+  currentIcon,
+}: EditNoteDialogProps) {
+  const { updateNote, isLoading } = useNoteMutations();
+
+  const form = useForm<UpdateHeaderNoteSchema>({
+    resolver: zodResolver(updateHeaderNoteSchema),
+    defaultValues: { title: currentTitle, icon: currentIcon ?? "" },
+  });
+
+  useEffect(() => {
+    if (open) {
+      form.reset({ title: currentTitle, icon: currentIcon ?? "" });
+    }
+  }, [open, currentTitle, currentIcon, form]);
+
+  const onSubmit = async (data: UpdateHeaderNoteSchema) => {
+    try {
+      await updateNote({ id: noteId, title: data.title, icon: data.icon || undefined });
+      toast.success("Nota atualizada!");
+      onOpenChange(false);
+    } catch {
+      toast.error("Erro ao atualizar nota. Tente novamente.");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle className="text-lg font-semibold">
+            Editar nota
+          </DialogTitle>
+          <DialogDescription>Altere o título e o ícone da nota.</DialogDescription>
+        </DialogHeader>
+
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="flex flex-col gap-6"
+        >
+          <FieldGroupApp<UpdateHeaderNoteSchema>
+            control={form.control}
+            align="inline-start"
+            firstElement={<Icon icon={File01Icon} />}
+            name="title"
+            label="Título da nota"
+            placeholder="Ex: Ideias para o próximo projeto"
+            className="rounded-xl"
+          />
+
+          <Controller
+            control={form.control}
+            name="icon"
+            render={({ field }) => (
+              <div className="space-y-1">
+                <span className="text-sm font-medium text-foreground">Ícone</span>
+                <IconPicker
+                  value={field.value || null}
+                  onChange={(name) => field.onChange(name ?? "")}
+                />
+              </div>
+            )}
+          />
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="secondary"
+              rounded="full"
+              onClick={() => onOpenChange(false)}
+              disabled={isLoading}
+            >
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={isLoading} rounded="full">
+              {isLoading ? (
+                <>
+                  <Icon
+                    icon={Loading02Icon}
+                    className="mr-2 animate-spin size-4"
+                  />
+                  <span className="sr-only">Salvando...</span>
+                </>
+              ) : (
+                "Salvar"
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/sidebar/NavNotes.tsx
+++ b/apps/web/src/components/sidebar/NavNotes.tsx
@@ -1,38 +1,56 @@
 /** biome-ignore-all lint/suspicious/noArrayIndexKey: Lint removido por se tratar de um elemento sem relevancia */
 "use client";
 
-import { MinusSignIcon, Plus } from "@hugeicons/core-free-icons";
+import {
+  MinusSignIcon,
+  MoreHorizontalCircle01Icon,
+  PencilEdit01Icon,
+  Plus,
+  Trash2,
+} from "@hugeicons/core-free-icons";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { useState } from "react";
+import { EditNoteDialog } from "@/components/notes/EditNoteDialog";
+import { Icon } from "@/components/shared/Icon";
 import { DialogApp } from "@/components/base/DialogApp";
 import { FormCreateNote } from "@/components/notes/FormCreateNote";
-import { Icon } from "@/components/shared/Icon";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   SidebarGroup,
   SidebarGroupAction,
   SidebarGroupLabel,
   SidebarMenu,
+  SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar";
-import { useWorkspace } from "@/context/workspace";
-import { useNotes } from "@/hook/notes/useNotes";
 import { resolveIcon } from "@/lib/icons";
 import { Skeleton } from "../ui/skeleton";
+import { useNavNotes } from "./hook/useNavNotes";
 
 export function NavNotes() {
-  const { data: notes = [], isLoading } = useNotes();
+  const {
+    notes,
+    notesSlice,
+    isLoading,
+    isAllNotes,
+    setIsAllNotes,
+    isCreateOpen,
+    setIsCreateOpen,
+    noteToRename,
+    setNoteToRename,
+    handleDelete,
+    workspaceSlug,
+    pathname,
+  } = useNavNotes();
   const { setOpenMobile, openMobile } = useSidebar();
-  const { workspaceSlug } = useWorkspace();
-
-  const pathname = usePathname();
-
-  const [isAllNotes, setIsAllNotes] = useState(false);
-  const [isCreateOpen, setIsCreateOpen] = useState(false);
-
-  const notesSlice = isAllNotes ? notes : notes.slice(0, 3);
 
   if (isLoading) {
     const skeletons = Array.from({ length: 3 }).map((_, i) => (
@@ -68,6 +86,45 @@ export function NavNotes() {
                 {note.icon && <Icon icon={resolveIcon(note.icon)} />}
                 <span>{note.title}</span>
               </SidebarMenuButton>
+
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  suppressHydrationWarning
+                  render={
+                    <SidebarMenuAction
+                      showOnHover
+                      className="aria-expanded:bg-sidebar-primary-foreground/30 text-sidebar-foreground hover:text-sidebar-foreground"
+                    />
+                  }
+                >
+                  <Icon icon={MoreHorizontalCircle01Icon} />
+                  <span className="sr-only">Mais opções</span>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  side="right"
+                  align="start"
+                  className="w-48 rounded-xl"
+                >
+                  <DropdownMenuGroup>
+                    <DropdownMenuLabel>Ações</DropdownMenuLabel>
+                    <DropdownMenuItem
+                      onClick={() =>
+                        setNoteToRename({ id: note.id, title: note.title, icon: note.icon ?? undefined })
+                      }
+                    >
+                      <Icon icon={PencilEdit01Icon} />
+                      <span>Editar</span>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      onClick={() => handleDelete(note.id)}
+                    >
+                      <Icon icon={Trash2} />
+                      <span>Deletar</span>
+                    </DropdownMenuItem>
+                  </DropdownMenuGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </SidebarMenuItem>
           ))}
           {notes.length > 3 && (
@@ -98,6 +155,14 @@ export function NavNotes() {
       >
         <FormCreateNote />
       </DialogApp>
+
+      <EditNoteDialog
+        open={noteToRename !== null}
+        onOpenChange={(open) => !open && setNoteToRename(null)}
+        noteId={noteToRename?.id ?? ""}
+        currentTitle={noteToRename?.title ?? ""}
+        currentIcon={noteToRename?.icon}
+      />
     </>
   );
 }

--- a/apps/web/src/components/sidebar/hook/useNavNotes.ts
+++ b/apps/web/src/components/sidebar/hook/useNavNotes.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import { useState } from "react";
+import { useWorkspace } from "@/context/workspace";
+import { useNoteMutations } from "@/hook/notes/useNote";
+import { useNotes } from "@/hook/notes/useNotes";
+
+export function useNavNotes() {
+  const { data: notes = [], isLoading } = useNotes();
+  const { deleteNote } = useNoteMutations();
+  const { workspaceSlug } = useWorkspace();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const [isAllNotes, setIsAllNotes] = useState(false);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [noteToRename, setNoteToRename] = useState<{
+    id: string;
+    title: string;
+    icon?: string;
+  } | null>(null);
+
+  const notesSlice = isAllNotes ? notes : notes.slice(0, 3);
+
+  const handleDelete = async (id: string) => {
+    if (pathname === `/${workspaceSlug}/notes/${id}`) {
+      router.push(`/${workspaceSlug}`);
+    }
+    await deleteNote(id);
+  };
+
+  return {
+    notes,
+    notesSlice,
+    isLoading,
+    isAllNotes,
+    setIsAllNotes,
+    isCreateOpen,
+    setIsCreateOpen,
+    noteToRename,
+    setNoteToRename,
+    handleDelete,
+    workspaceSlug,
+    pathname,
+  };
+}


### PR DESCRIPTION
Adds a dropdown menu (hover trigger) to each note in the sidebar with "Editar" (title + icon picker) and "Deletar" options, mirroring the pattern already used for collections. Deleting the active note redirects to the workspace root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added modal dialog to edit note titles and icons
  * Introduced dropdown menu for each sidebar note with rename and delete actions
  * Enhanced note state management within the sidebar interface

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ali-ali18/locus-refs/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->