### PR TITLE
feat(upload): standardize image upload and cleanup old workspace logo

### DIFF
--- a/apps/web/src/app/api/upload/workspace-logo/route.ts
+++ b/apps/web/src/app/api/upload/workspace-logo/route.ts
@@ -3,6 +3,7 @@ import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { type NextRequest, NextResponse } from "next/server";
 import { s3Client } from "@/lib/storage";
 import { requireWorkspaceAccess } from "@/server/requireSession";
+import { deleteObjects } from "@/server/upload";
 
 const ALLOWED_EXTENSIONS = new Set(["jpg", "jpeg", "png", "webp", "gif"]);
 
@@ -96,5 +97,31 @@ export async function POST(request: NextRequest) {
       data: { publicUrl: `/storage/${key}` },
     },
     { status: 201 },
+  );
+}
+
+export async function DELETE(request: NextRequest) {
+  const auth = await requireWorkspaceAccess(request);
+  if ("error" in auth) return auth.error;
+  const { workspaceId } = auth;
+
+  const { oldUrl } = (await request.json().catch(() => ({}))) as {
+    oldUrl?: string;
+  };
+
+  if (!oldUrl?.startsWith("/storage/")) {
+    return NextResponse.json({ error: "URL inválida" }, { status: 400 });
+  }
+
+  const key = oldUrl.replace(/^\/storage\//, "");
+  if (!key.startsWith(`${workspaceId}/workspaceLogo/`)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  await deleteObjects([key]);
+
+  return NextResponse.json(
+    { message: "Logo antiga removida" },
+    { status: 200 },
   );
 }

--- a/apps/web/src/components/ui/baseNote/imageBlock/useImageUpload.ts
+++ b/apps/web/src/components/ui/baseNote/imageBlock/useImageUpload.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { api } from "@/lib/api";
 
 export function useImageUpload() {
   const [isUploading, setIsUploading] = useState(false);
@@ -10,23 +11,11 @@ export function useImageUpload() {
     try {
       const formData = new FormData();
       formData.append("file", file);
-      const res = await fetch("/api/upload/notes", {
-        method: "POST",
-        body: formData,
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ??
-            "Erro ao fazer upload da imagem.",
-        );
-      }
-      const { data } = (await res.json()) as { data: { publicUrl: string } };
-      return data.publicUrl;
-    } catch (err) {
-      throw err instanceof Error
-        ? err
-        : new Error("Erro ao fazer upload da imagem.");
+      const { data } = await api.post<{ data: { publicUrl: string } }>(
+        "/api/upload/notes",
+        formData,
+      );
+      return data.data.publicUrl;
     } finally {
       setIsUploading(false);
     }

--- a/apps/web/src/components/workspace/config/WorkspaceConfig.tsx
+++ b/apps/web/src/components/workspace/config/WorkspaceConfig.tsx
@@ -81,6 +81,7 @@ export function WorkspaceConfig() {
       slug: data.slug ?? workspaceSlug,
       logo: data.logo,
       logoFile,
+      previousLogo: workspaceLogo,
     });
   }
 

--- a/apps/web/src/hook/workspace/useWorkspaceSettings.ts
+++ b/apps/web/src/hook/workspace/useWorkspaceSettings.ts
@@ -13,6 +13,7 @@ interface UpdateWorkspaceParams {
   slug: string;
   logo?: string;
   logoFile?: File;
+  previousLogo?: string | null;
 }
 
 export function useWorkspaceSettings() {
@@ -26,6 +27,7 @@ export function useWorkspaceSettings() {
       slug,
       logo,
       logoFile,
+      previousLogo,
     }: UpdateWorkspaceParams) => {
       let resolvedLogo = logo;
 
@@ -40,6 +42,19 @@ export function useWorkspaceSettings() {
 
       if (error)
         throw new Error(error.message ?? "Erro ao atualizar workspace");
+
+      if (
+        previousLogo &&
+        previousLogo !== resolvedLogo &&
+        previousLogo.startsWith("/storage/")
+      ) {
+        api
+          .delete("/api/upload/workspace-logo", {
+            data: { oldUrl: previousLogo },
+          })
+          .catch(() => {});
+      }
+
       return data;
     },
     onSuccess: (data) => {


### PR DESCRIPTION
- replace fetch with shared axios client in useImageUpload so the x-workspace-id header is sent (fixes 400 on note image uploads)
- add DELETE /api/upload/workspace-logo that validates workspace ownership of the key prefix and deletes the old object
- fire-and-forget cleanup in useWorkspaceSettings after the org update succeeds, using the original workspaceLogo from context (the form value gets overwritten with a data URL on file pick)