### PR TITLE
fix(deps): aprovar build scripts (workerd, prisma, esbuild, sharp)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,16 @@
     "@tiptap/pm": "3.20.4",
     "@tiptap/react": "3.20.4",
     "@tiptap/starter-kit": "3.20.4"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "workerd",
+      "@prisma/client",
+      "@prisma/engines",
+      "prisma",
+      "esbuild",
+      "sharp",
+      "@parcel/watcher"
+    ]
   }
 }


### PR DESCRIPTION
O pnpm 11 bloqueia por padrão scripts de build de pacotes não aprovados, e o build do Docker falhava com exit code 1 ao final do 'install --frozen-lockfile':

  [ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: workerd@1.20250718.0

O workerd é dep transitiva do wrangler/miniflare (tldraw-sync), e seu postinstall baixa o binário nativo necessário para o Worker rodar em dev. Adicionar outros pacotes comuns de postinstall (prisma, esbuild, sharp, @parcel/watcher) para evitar surpresas futuras quando o lockfile evoluir.