### PR TITLE
fix(deps): mover pnpm.onlyBuiltDependencies para o nível raiz

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,15 +46,14 @@
     "@tiptap/react": "3.20.4",
     "@tiptap/starter-kit": "3.20.4"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "workerd",
-      "@prisma/client",
-      "@prisma/engines",
-      "prisma",
-      "esbuild",
-      "sharp",
-      "@parcel/watcher"
-    ]
-  }
+  "onlyBuiltDependencies": [
+    "workerd",
+    "@prisma/client",
+    "@prisma/engines",
+    "prisma",
+    "esbuild",
+    "sharp",
+    "@parcel/watcher"
+  ]
 }
+


### PR DESCRIPTION
Mesmo problema do commit anterior: pnpm 11 ignora o wrapper 'pnpm.X' e lê apenas 'X' no nível raiz do package.json. O campo 'pnpm.onlyBuiltDependencies' estava sendo ignorado e o build falhava com ERR_PNPM_IGNORED_BUILDS.

Mover para o nível raiz, junto com 'overrides'.