### PR TITLE
fix(landing): corrigir acentos faltando em 3 secoes da landing

### DIFF
--- a/apps/web/src/components/landing/Demo.tsx
+++ b/apps/web/src/components/landing/Demo.tsx
@@ -37,15 +37,15 @@ const demoItems: DemoItem[] = [
       "Adicione novas referencias a partir de URLs e concentre o material relevante sem depender de processos manuais.",
     image:
       "https://images.unsplash.com/photo-1759222196651-cac4bb9da047?w=1200&auto=format&fit=crop&q=80",
-    imageAlt: "Preview da captura automatica de referencias",
+    imageAlt: "Preview da captura automática de referências",
     icon: Share07Icon,
-    previewLabel: "Coleta automatica",
+    previewLabel: "Coleta automática",
   },
   {
     id: "notes",
     title: "Notas em formato de workspace",
     description:
-      "Organize conhecimento em paginas editaveis, conecte contexto da equipe e mantenha tudo acessivel em um unico lugar.",
+      "Organize conhecimento em páginas editáveis, conecte contexto da equipe e mantenha tudo acessível em um único lugar.",
     image:
       "https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=1200&auto=format&fit=crop&q=80",
     imageAlt: "Preview do workspace de notas",
@@ -54,14 +54,14 @@ const demoItems: DemoItem[] = [
   },
   {
     id: "search",
-    title: "Consulta e reutilizacao rapida",
+    title: "Consulta e reutilização rápida",
     description:
-      "Transforme referencias e notas em uma base pronta para consulta, documentacao interna e evolucao continua do time.",
+      "Transforme referências e notas em uma base pronta para consulta, documentação interna e evolução contínua do time.",
     image:
       "https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=1200&auto=format&fit=crop&q=80",
     imageAlt: "Preview da consulta de conhecimento",
     icon: SearchList01Icon,
-    previewLabel: "Base consultavel",
+    previewLabel: "Base consultável",
   },
 ];
 
@@ -104,11 +104,12 @@ export function DemoContent() {
         <div className="grid grid-cols-1 items-center gap-4 px-5 md:grid-cols-[minmax(0,1fr)_auto]">
           <div className="max-w-xl space-y-1.5">
             <h2 className="text-lg font-semibold tracking-tight">
-              Capture referencias, organize notas e mantenha o contexto vivo
+              Capture referências, organize notas e mantenha o contexto vivo
             </h2>
             <p className="text-sm leading-6 text-muted-foreground">
-              Una scraping automatico, notas em formato de workspace e uma base
-              pronta para o time registrar, consultar e evoluir conhecimento.
+              Combine o scraping automático, notas em formato de workspace e
+              uma base pronta para o time registrar, consultar e evoluir
+              conhecimento.
             </p>
           </div>
           <Button
@@ -116,7 +117,7 @@ export function DemoContent() {
             className="w-full lg:w-fit lg:justify-self-end"
             size="lg"
           >
-            Documentacao
+            Documentação
           </Button>
         </div>
       </div>

--- a/apps/web/src/components/landing/Header.tsx
+++ b/apps/web/src/components/landing/Header.tsx
@@ -83,7 +83,7 @@ export function ContentHeader() {
             <DrawerHeader className="font-medium text-lg">
               <DrawerTitle>Para onde vamos agora?</DrawerTitle>
               <DrawerDescription>
-                Selecione seu destino, e veja a magica acontecer...
+                Selecione seu destino, e veja a mágica acontecer...
               </DrawerDescription>
             </DrawerHeader>
             <nav className="flex flex-col gap-0.5 p-4 md:gap-1.5 md:text-left">

--- a/apps/web/src/components/landing/Stack.tsx
+++ b/apps/web/src/components/landing/Stack.tsx
@@ -138,7 +138,7 @@ function NoiseOverlay() {
 const stackItems: StackItem[] = [
   {
     name: "Next.js",
-    role: "App Router e rendering",
+    role: "App Router e renderização",
     preview: "N",
     icon: <NextJsMark />,
     panelClassName:
@@ -146,7 +146,7 @@ const stackItems: StackItem[] = [
   },
   {
     name: "PostgreSQL",
-    role: "Persistencia relacional",
+    role: "Persistência relacional",
     preview: "DB",
     icon: <Icon icon={Database02Icon} className="size-16 text-white" />,
     panelClassName:
@@ -154,7 +154,7 @@ const stackItems: StackItem[] = [
   },
   {
     name: "TypeScript",
-    role: "Contratos e manutencao",
+    role: "Contratos e manutenção",
     preview: "TS",
     icon: <TypeScriptMark />,
     panelClassName:
@@ -162,7 +162,7 @@ const stackItems: StackItem[] = [
   },
   {
     name: "React Query",
-    role: "Cache e sincronizacao",
+    role: "Cache e sincronização",
     preview: "RQ",
     icon: <ReactQueryMark />,
     panelClassName:
@@ -194,23 +194,23 @@ function StackContent() {
           <div className="flex flex-col gap-5">
             <div className="flex flex-col gap-3">
               <h3 className="max-w-lg text-xl font-semibold tracking-tight text-balance">
-                Base moderna para manter o produto rapido de evoluir.
+                Base moderna para manter o produto rápido de evoluir.
               </h3>
               <Button size="lg" className="hidden sm:w-fit sm:flex">
-                Ver repositorio
+                Ver repositório
                 <Icon icon={Github} data-icon="inline-end" />
               </Button>
             </div>
           </div>
 
           <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
-            A implementacao combina Next.js, TypeScript, PostgreSQL, Better Auth
-            e outras pecas que fazem sentido para uma plataforma de referencias
-            colaborativas. O objetivo aqui nao e empilhar modismo, e sim manter
+            A implementação combina Next.js, TypeScript, PostgreSQL, Better Auth
+            e outras peças que fazem sentido para uma plataforma de referências
+            colaborativas. O objetivo aqui não é empilhar modismo, é sim manter
             uma base clara para operar, testar e continuar expandindo.
           </p>
           <Button size="lg" className="w-full sm:hidden">
-            Ver repositorio
+            Ver repositório
             <Icon icon={Github} data-icon="inline-end" />
           </Button>
         </div>


### PR DESCRIPTION
Corrige 29 ocorrencias de acento (ortografia) e 1 reescrita leve de copy em Stack.tsx, Demo.tsx e Header.tsx.

A reescrita: "Una scraping automatico" virou "Combine o scraping automatico" (melhor gramatica em pt-BR).

Nenhum outro arquivo foi tocado.
Branch: fix/landing-acentos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Portuguese language content across landing page sections, including hero section copy, feature descriptions, preview labels, drawer descriptions, and action button labels. Updates implement corrected spelling and improved diacritical marks (accents) throughout for enhanced consistency, clarity, and professional presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->