### PR TITLE
fix(auth): evitar crash no layout 

### DIFF
--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -15,7 +15,7 @@ export default async function AuthLayout({ children }: Props) {
   const requestHeaders = await headers();
   const [session, orgs] = await Promise.all([
     getSession(),
-    auth.api.listOrganizations({ headers: requestHeaders }),
+    auth.api.listOrganizations({ headers: requestHeaders }).catch(() => []),
   ]);
 
   if (session) {


### PR DESCRIPTION
## Summary

- `listOrganizations` lançava `Unauthorized` para usuários sem sessão,
  causando 500 em `GET /login`
- Fix: `.catch(() => [])` mantém a paralelização sem quebrar a página

## Root cause

O commit `perf(auth): parallelize session and orgs lookup` passou a
executar `listOrganizations` em paralelo com `getSession`, mas a API
exige autenticação e explode quando não há sessão ativa.
