### PR TITLE
fix(seo): corrigir nome do projeto na metadata description

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -11,7 +11,7 @@ const nunito = Nunito({ subsets: ["latin"], variable: "--font-sans" });
 export const metadata: Metadata = {
   title: "Locus",
   description:
-    "Refstash é um projeto de referência para o desenvolvimento de aplicativos web modernos.",
+    "Locus é um projeto de referência para o desenvolvimento de aplicativos web modernos.",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
A descrição referenciava "Refstash" (nome antigo) em vez de "Locus".

Closes #17