### PR TITLE
Fix/idor category ids patch

### DIFF
--- a/apps/web/src/app/api/resources/[id]/route.test.ts
+++ b/apps/web/src/app/api/resources/[id]/route.test.ts
@@ -2,16 +2,21 @@ import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DELETE, PATCH } from "./route";
 
-const { mockFindFirst, mockFindUnique, mockUpdate, mockDelete } = vi.hoisted(
-  () => {
-    return {
-      mockFindFirst: vi.fn(),
-      mockFindUnique: vi.fn(),
-      mockUpdate: vi.fn(),
-      mockDelete: vi.fn(),
-    };
-  },
-);
+const {
+  mockFindFirst,
+  mockFindUnique,
+  mockCategoryFindMany,
+  mockUpdate,
+  mockDelete,
+} = vi.hoisted(() => {
+  return {
+    mockFindFirst: vi.fn(),
+    mockFindUnique: vi.fn(),
+    mockCategoryFindMany: vi.fn(),
+    mockUpdate: vi.fn(),
+    mockDelete: vi.fn(),
+  };
+});
 
 vi.mock("server-only", () => ({}));
 
@@ -31,6 +36,9 @@ vi.mock("@/lib/prisma", () => ({
     },
     collection: {
       findUnique: mockFindUnique,
+    },
+    category: {
+      findMany: mockCategoryFindMany,
     },
   },
 }));
@@ -166,6 +174,35 @@ describe("API Resource [id]", () => {
 
       expect(response.status).toBe(404);
       expect(data).toEqual({ error: "Collection not found" });
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when categoryIds belong to a different workspace (IDOR)", async () => {
+      mockFindFirst.mockResolvedValue({ id: resourceId, collectionId: "col-1" });
+      mockCategoryFindMany.mockResolvedValue([{ id: "cat-other-ws" }]);
+
+      const req = new NextRequest(
+        `http://localhost/api/resources/${resourceId}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            categoryIds: ["cat-other-ws", "cat-another-ws"],
+          }),
+        },
+      );
+
+      const response = await PATCH(req, { params: createParams() });
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data).toEqual({ error: "Invalid category" });
+      expect(mockCategoryFindMany).toHaveBeenCalledWith({
+        where: {
+          id: { in: ["cat-other-ws", "cat-another-ws"] },
+          workspaceId: "ws-1",
+        },
+        select: { id: true },
+      });
       expect(mockUpdate).not.toHaveBeenCalled();
     });
 

--- a/apps/web/src/app/api/resources/[id]/route.ts
+++ b/apps/web/src/app/api/resources/[id]/route.ts
@@ -40,6 +40,19 @@ export async function PATCH(
     }
   }
 
+  if (body.categoryIds !== undefined && body.categoryIds.length > 0) {
+    const validCategories = await prisma.category.findMany({
+      where: { id: { in: body.categoryIds }, workspaceId },
+      select: { id: true },
+    });
+    if (validCategories.length !== body.categoryIds.length) {
+      return NextResponse.json(
+        { error: "Invalid category" },
+        { status: 400 },
+      );
+    }
+  }
+
   const updateData: Prisma.ResourceUncheckedUpdateInput = {};
   if (body.title !== undefined) updateData.title = body.title;
   if (body.description !== undefined) updateData.description = body.description;

--- a/apps/web/src/app/api/resources/[id]/route.ts
+++ b/apps/web/src/app/api/resources/[id]/route.ts
@@ -45,7 +45,8 @@ export async function PATCH(
       where: { id: { in: body.categoryIds }, workspaceId },
       select: { id: true },
     });
-    if (validCategories.length !== body.categoryIds.length) {
+    const validIds = new Set(validCategories.map((c) => c.id));
+    if (body.categoryIds.some((id) => !validIds.has(id))) {
       return NextResponse.json(
         { error: "Invalid category" },
         { status: 400 },

--- a/apps/web/src/app/api/resources/route.ts
+++ b/apps/web/src/app/api/resources/route.ts
@@ -64,7 +64,8 @@ export async function POST(request: NextRequest) {
       where: { id: { in: categoryIds }, workspaceId },
       select: { id: true },
     });
-    if (validCategories.length !== categoryIds.length) {
+    const validIds = new Set(validCategories.map((c) => c.id));
+    if (categoryIds.some((id: string) => !validIds.has(id))) {
       return NextResponse.json(
         { error: "Invalid category" },
         { status: 400 },


### PR DESCRIPTION
## Summary

- Valida que os `categoryIds` enviados no `PATCH /api/resources/[id]` pertencem ao workspace antes de atualizar (IDOR)
- Corrige a validação em ambos os endpoints (`POST` e `PATCH`) para comparar os IDs explicitamente via `Set` em vez de comparar apenas o tamanho da lista — o length check falhava com IDs duplicados no input

Closes #12