### PR TITLE
fix(layout): corrigir overflow horizontal no editor e header mobile

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -257,6 +257,11 @@
   --shadow-2xl: var(--shadow-2xl);
 }
 
+
+.tiptap {
+  overflow-wrap: anywhere;
+}
+
 .tiptap p.is-empty::before,
 .tiptap h1.is-empty::before,
 .tiptap h2.is-empty::before,

--- a/apps/web/src/components/breadcrumb/BreadcrumbRenderer.tsx
+++ b/apps/web/src/components/breadcrumb/BreadcrumbRenderer.tsx
@@ -92,7 +92,7 @@ export function BreadcrumbRenderer({ items }: BreadcrumbRendererProps) {
           <>
             <BreadcrumbSeparator />
             <BreadcrumbItem>
-              <BreadcrumbPage className="flex max-w-48 items-center gap-1.5 truncate">
+              <BreadcrumbPage className="flex max-w-28 items-center gap-1.5 truncate sm:max-w-48">
                 <ItemIcon icon={last.icon} />
                 <span className="truncate">{last.label}</span>
               </BreadcrumbPage>

--- a/apps/web/src/components/dashboard/DashboardLayoutHeader.tsx
+++ b/apps/web/src/components/dashboard/DashboardLayoutHeader.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { SidebarLeftIcon } from "@hugeicons/core-free-icons";
+import {
+  BubbleChatIcon,
+  Moon02Icon,
+  MoreVerticalIcon,
+  SidebarLeftIcon,
+  Sun03Icon,
+} from "@hugeicons/core-free-icons";
 import { usePathname } from "next/navigation";
+import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 import { BreadcrumbRenderer } from "@/components/breadcrumb/BreadcrumbRenderer";
 import { useSidebar } from "@/components/ui/sidebar";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useChatPanel } from "@/context/chatPanel";
+import { useIsMobile } from "@/hook/use-mobile";
 import { resolveBreadcrumb } from "@/lib/breadcrumb/actions/resolve-breadcrumb";
 import type { BreadcrumbItem } from "@/lib/breadcrumb/route-resolvers";
 import { cn } from "@/lib/utils";
@@ -13,12 +22,23 @@ import { ButtonChatPanel } from "../chat/ButtonChatPanel";
 import { Icon } from "../shared/Icon";
 import { ButtonTheme } from "../shared/ToggleButton";
 import { Button } from "../ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
 
 export function DashboardLayoutHeader() {
   const { toggleSidebar } = useSidebar();
   const pathname = usePathname();
   const [items, setItems] = useState<BreadcrumbItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const isMobile = useIsMobile();
+  const { toggle: toggleChat } = useChatPanel();
+  const { theme, setTheme } = useTheme();
 
   useEffect(() => {
     async function loadBreadcrumb() {
@@ -39,10 +59,10 @@ export function DashboardLayoutHeader() {
   return (
     <header
       className={cn(
-        "flex py-2.5 items-center justify-between gap-2 border-b px-1.5 transition-[padding] duration-300",
+        "flex items-center justify-between gap-2 border-b px-1.5 py-2.5 transition-[padding] duration-300",
       )}
     >
-      <div className="flex items-center justify-center gap-1.5">
+      <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
         <Button
           size={"icon-sm"}
           rounded={"xl"}
@@ -60,9 +80,36 @@ export function DashboardLayoutHeader() {
         )}
       </div>
 
-      <div className="flex items-center gap-1">
-        <ButtonChatPanel />
-        <ButtonTheme />
+      <div className="flex shrink-0 items-center gap-1">
+        {isMobile ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={<Button variant="ghost" size="icon-sm" rounded="xl" />}
+            >
+              <Icon icon={MoreVerticalIcon} className="size-4.5" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent side="bottom" align="end" className={"w-40"}>
+              <DropdownMenuGroup>
+                <DropdownMenuLabel>Interações</DropdownMenuLabel>
+                <DropdownMenuItem onClick={toggleChat}>
+                  <Icon icon={BubbleChatIcon} />
+                  Assistente IA
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+                >
+                  <Icon icon={theme === "dark" ? Moon02Icon : Sun03Icon} />
+                  {theme === "dark" ? "Modo claro" : "Modo escuro"}
+                </DropdownMenuItem>
+              </DropdownMenuGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          <>
+            <ButtonChatPanel />
+            <ButtonTheme />
+          </>
+        )}
       </div>
     </header>
   );

--- a/apps/web/src/components/ui/baseNote/roadmapBlock/RoadmapBlockView.tsx
+++ b/apps/web/src/components/ui/baseNote/roadmapBlock/RoadmapBlockView.tsx
@@ -6,9 +6,9 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "../../tooltip";
 import { AddItemPopover } from "./AddItemPopover";
 import { CalendarTab } from "./CalendarTab";
 import { GanttTab } from "./GanttTab";
+import { useRoadmapBlock } from "./hook/useRoadmapBlock";
 import { KanbanTab } from "./KanbanTab";
 import { ListTab } from "./ListTab";
-import { useRoadmapBlock } from "./hook/useRoadmapBlock";
 
 export function RoadmapBlockView({ node, updateAttributes }: NodeViewProps) {
   const {
@@ -24,7 +24,7 @@ export function RoadmapBlockView({ node, updateAttributes }: NodeViewProps) {
   } = useRoadmapBlock({ node, updateAttributes });
 
   return (
-    <NodeViewWrapper contentEditable={false} className="my-4">
+    <NodeViewWrapper contentEditable={false} className="my-4 w-full">
       <div className="overflow-hidden rounded-2xl border border-border bg-card">
         <Tabs defaultValue="gantt" className={"gap-0"}>
           <div className="flex items-center justify-between border-b px-3 py-1">

--- a/apps/web/src/components/workspace/WorkspaceShell.tsx
+++ b/apps/web/src/components/workspace/WorkspaceShell.tsx
@@ -8,7 +8,7 @@ export function WorkspaceShell({ children }: { children: ReactNode }) {
   return (
     <>
       <AppSidebar />
-      <div className="flex flex-1 flex-col">
+      <div className="flex min-w-0 flex-1 flex-col">
         <DashboardLayoutHeader />
         {children}
       </div>

--- a/apps/web/src/lib/notes-editor-config.ts
+++ b/apps/web/src/lib/notes-editor-config.ts
@@ -46,11 +46,9 @@ export interface NotesEditorExtensionsOptions {
 }
 
 function renderCaretLabel(user: CollabUser): HTMLElement {
-  // Cursor line — position:relative so the label can float above via position:absolute
   const cursor = document.createElement("span");
   cursor.style.cssText = `border-left:2px solid ${user.color};margin-left:-1px;pointer-events:none;position:relative;word-break:normal;`;
 
-  // Floating bubble label — bottom:100% places it above the cursor without affecting text flow
   const label = document.createElement("span");
   label.style.cssText = `position:absolute;bottom:100%;left:-1px;display:inline-flex;align-items:center;gap:4px;border-radius:12px 12px 12px 0;padding:2px 8px 2px 4px;font-size:11px;font-weight:600;color:#fff;white-space:nowrap;pointer-events:none;box-shadow:0 2px 6px rgba(0,0,0,0.2);z-index:50;animation:collab-caret-fade-in 0.2s ease-out;background-color:${user.color};`;
 
@@ -169,6 +167,6 @@ export function getNotesEditorExtensions(
 export const NOTES_EDITOR_PROPS = {
   attributes: {
     class:
-      "focus:outline-none min-h-[200px] px-1 py-2 space-y-4 overflow-x-hidden overflow-y-hidden",
+      "focus:outline-none min-h-[200px] px-1 py-2 space-y-4 ",
   },
 };


### PR DESCRIPTION
- WorkspaceShell: adicionar min-w-0 ao flex item para conter o overflow horizontal
- globals.css: overflow-wrap: anywhere no .tiptap para quebrar tokens longos
- notes-editor-config: remover overflow-x/y-hidden do NOTES_EDITOR_PROPS
- RoadmapBlockView: adicionar w-full ao NodeViewWrapper para conter o bloco Gantt
- DashboardLayoutHeader: min-w-0/flex-1 no left div + dropdown mobile para chat e tema
- BreadcrumbRenderer: truncação responsiva max-w-28 sm:max-w-48 no último item

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mobile dashboard now displays a dropdown menu with AI Assistant and theme toggle options.

* **Bug Fixes**
  * Improved text wrapping for long, unbroken content in the editor.
  * Corrected breadcrumb width constraints on mobile devices.
  * Resolved layout spacing and overflow handling in editor and workspace containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->