### PR TITLE
fix(auth): redirecionar para login quando a sessão expira no cliente

### DIFF
--- a/apps/web/src/app/[workspaceSlug]/layout.tsx
+++ b/apps/web/src/app/[workspaceSlug]/layout.tsx
@@ -4,6 +4,7 @@ import { ChatPanel } from "@/components/chat/ChatPanel";
 import { ThemeProvider } from "@/components/shared/ThemeProvider";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { SettingsDialog } from "@/components/workspace/SettingsDialog";
+import { SessionGuard } from "@/components/workspace/SessionGuard";
 import { WorkspaceShell } from "@/components/workspace/WorkspaceShell";
 import { ChatPanelProvider } from "@/context/chatPanel";
 import { NoteEditorProvider } from "@/context/noteEditor";
@@ -52,6 +53,7 @@ export default async function WorkspaceLayout({ children, params }: Props) {
             <SettingsDialogProvider>
               <SidebarTabProvider>
                 <SidebarProvider>
+                  <SessionGuard />
                   <WorkspaceShell>{children}</WorkspaceShell>
                   <ChatPanel />
                   <SettingsDialog />

--- a/apps/web/src/components/workspace/SessionGuard.tsx
+++ b/apps/web/src/components/workspace/SessionGuard.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { useSession } from "@/lib/auth-client";
+
+export function SessionGuard() {
+  const { data: session, isPending } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isPending && !session) {
+      router.push("/login");
+    }
+  }, [session, isPending, router]);
+
+  return null;
+}


### PR DESCRIPTION
Adiciona SessionGuard ao workspace layout para monitorar a sessão via useSession (Better Auth) e redirecionar para /login quando o token expira enquanto o usuário já está autenticado na página.